### PR TITLE
Remove node-fetch dependency

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,3 @@
-src/
 test/
 coverage/
+.babelrc

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A [Universal JavaScript](https://medium.com/@mjackson/universal-javascript-47610
 --- | --- | --- | --- | --- |
 Latest ✔ | Latest ✔ | Latest ✔ | Latest ✔ | 10+ ✔ |
 
+
 ## Documentation
 - [Installation](https://github.com/unsplash/unsplash-js#installation)
 - [Dependencies](https://github.com/unsplash/unsplash-js#dependencies)
@@ -34,7 +35,9 @@ This library depends on [fetch](https://fetch.spec.whatwg.org/) to make requests
 To create an instance, simply provide an _Object_ with your `applicationId`, `secret` and `callbackUrl`.
 
 ```js
-let unsplash = new Unsplash({
+import Unsplash from 'unsplash-js';
+
+const unsplash = new Unsplash({
   applicationId: "{APP_ID}",
   secret: "{APP_SECRET}",
   callbackUrl: "{CALLBACK_URL}"
@@ -44,7 +47,7 @@ let unsplash = new Unsplash({
 If you already have a bearer token, you can also provide it to the constructor.
 
 ```js
-let unsplash = new Unsplash({
+const unsplash = new Unsplash({
   applicationId: "{APP_ID}",
   secret: "{APP_SECRET}",
   callbackUrl: "{CALLBACK_URL}",
@@ -53,6 +56,13 @@ let unsplash = new Unsplash({
 ```
 
 _Credentials can be obtained from [Unsplash Developers](https://unsplash.com/developers)._
+
+### React Native
+For use with React Native, import from `unsplash-js/native` instead.
+
+```js
+import Unsplash from 'unsplash-js/native';
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Unsplash
 
 [![npm](https://img.shields.io/npm/v/unsplash-js.svg?style=flat-square)](https://www.npmjs.com/package/unsplash-js)
-[![Travis](https://img.shields.io/travis/naoufal/unsplash-js/master.svg?style=flat-square)](https://travis-ci.org/naoufal/unsplash-js/branches)
-[![Coveralls](https://img.shields.io/coveralls/naoufal/unsplash-js/master.svg?style=flat-square)](https://coveralls.io/github/naoufal/unsplash-js?branch=master)
+[![Travis](https://img.shields.io/travis/unsplash/unsplash-js/master.svg?style=flat-square)](https://travis-ci.org/naoufal/unsplash-js/branches)
+[![Coveralls](https://img.shields.io/coveralls/unsplash/unsplash-js/master.svg?style=flat-square)](https://coveralls.io/github/naoufal/unsplash-js?branch=master)
 
 A [Universal JavaScript](https://medium.com/@mjackson/universal-javascript-4761051b7ae9) wrapper for the [Unsplash API](https://unsplash.com/developers).
 
@@ -13,13 +13,13 @@ A [Universal JavaScript](https://medium.com/@mjackson/universal-javascript-47610
 Latest ✔ | Latest ✔ | Latest ✔ | Latest ✔ | 10+ ✔ |
 
 ## Documentation
-- [Installation](https://github.com/naoufal/unsplash-js#installation)
-- [Dependencies](https://github.com/naoufal/unsplash-js#dependencies)
-- [Usage](https://github.com/naoufal/unsplash-js#usage)
-- [Instance Methods](https://github.com/naoufal/unsplash-js#instance-methods)
-- [Helpers](https://github.com/naoufal/unsplash-js#helpers)
-- [Shoutouts](https://github.com/naoufal/unsplash-js#shoutouts)
-- [License](https://github.com/naoufal/unsplash-js#license)
+- [Installation](https://github.com/unsplash/unsplash-js#installation)
+- [Dependencies](https://github.com/unsplash/unsplash-js#dependencies)
+- [Usage](https://github.com/unsplash/unsplash-js#usage)
+- [Instance Methods](https://github.com/unsplash/unsplash-js#instance-methods)
+- [Helpers](https://github.com/unsplash/unsplash-js#helpers)
+- [Shoutouts](https://github.com/unsplash/unsplash-js#shoutouts)
+- [License](https://github.com/unsplash/unsplash-js#license)
 
 ## Installation
 ```bash
@@ -27,7 +27,7 @@ $ npm i --save unsplash-js
 ```
 
 ## Dependencies
-This library depends on [fetch](https://fetch.spec.whatwg.org/) to make requests to the Unsplash API.  __For browsers__ that don't support fetch, you'll need to provide a [poly](https://github.com/github/fetch)[fill](https://cdnjs.com/libraries/fetch).
+This library depends on [fetch](https://fetch.spec.whatwg.org/) to make requests to the Unsplash API.  For environments that don't support fetch, you'll need to provide a [poly](https://github.com/github/fetch)[fill](https://github.com/bitinn/node-fetch).
 
 ## Usage
 ### Creating an instance
@@ -102,13 +102,13 @@ unsplash.users.profile("naoufal")
 ---
 
 ## Instance Methods
-- [Authorization](https://github.com/naoufal/unsplash-js#authorization)
-- [Current User](https://github.com/naoufal/unsplash-js#current-user)
-- [Users](https://github.com/naoufal/unsplash-js#users)
-- [Photos](https://github.com/naoufal/unsplash-js#photos)
-- [Categories](https://github.com/naoufal/unsplash-js#categories)
-- [Collections](https://github.com/naoufal/unsplash-js#collections)
-- [Stats](https://github.com/naoufal/unsplash-js#stats)
+- [Authorization](https://github.com/unsplash/unsplash-js#authorization)
+- [Current User](https://github.com/unsplash/unsplash-js#current-user)
+- [Users](https://github.com/unsplash/unsplash-js#users)
+- [Photos](https://github.com/unsplash/unsplash-js#photos)
+- [Categories](https://github.com/unsplash/unsplash-js#categories)
+- [Collections](https://github.com/unsplash/unsplash-js#collections)
+- [Stats](https://github.com/unsplash/unsplash-js#stats)
 
 <div id="authorization" />
 
@@ -767,7 +767,7 @@ unsplash.stats.total()
 - Shoutout to [BrowserStack](https://www.browserstack.com/) for letting us use their service to run automated browser tests.
 
 ## License
-Copyright (c) 2015, [Naoufal Kadhom](http://naoufal.com)
+Copyright (c) 2015, [Unsplash](https://unsplash.com)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/examples/node/index.js
+++ b/examples/node/index.js
@@ -1,3 +1,5 @@
 require('babel-register');
 
+global.fetch = require('node-fetch');
+
 require('./app');

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "babel-register": "6.6.5",
+    "node-fetch": "1.5.0",
     "universal-config": "0.1.0",
     "unsplash-js": "../.."
   }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -33,9 +33,7 @@ const baseConfig = {
       new webpack.DefinePlugin({
         'process.env.NODE_ENV': JSON.stringify('production'),
         'process.browser': true
-      }),
-      new webpack.IgnorePlugin(/^form-data/),
-      new webpack.IgnorePlugin(/^node-fetch/)
+      })
     ]
   },
   webpackMiddleware: {

--- a/native.js
+++ b/native.js
@@ -1,0 +1,1 @@
+module.exports = require('./src/unsplash');

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "npm run lint && npm run flow && npm run test:node && npm run test:browser",
     "test:browser": "karma start",
     "test:ci": "npm run lint && npm run flow && npm run test:browser && npm run test:coverage",
-    "test:coverage": "babel-node ./node_modules/.bin/isparta cover _mocha",
+    "test:coverage": "babel-node ./node_modules/.bin/isparta cover _mocha -- --require test/setup",
     "test:node": "mocha --compilers js:babel-core/register --require test/setup --recursive",
     "test:watch": "npm test -- --watch"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:browser": "karma start",
     "test:ci": "npm run lint && npm run flow && npm run test:browser && npm run test:coverage",
     "test:coverage": "babel-node ./node_modules/.bin/isparta cover _mocha",
-    "test:node": "mocha --compilers js:babel-core/register --recursive",
+    "test:node": "mocha --compilers js:babel-core/register --require test/setup --recursive",
     "test:watch": "npm test -- --watch"
   },
   "repository": {
@@ -63,11 +63,11 @@
     "karma-webpack": "1.7.0",
     "mocha": "2.3.3",
     "mockery": "1.4.0",
+    "node-fetch": "1.5.0",
     "webpack": "1.12.14"
   },
   "dependencies": {
     "form-urlencoded": "1.2.0",
-    "node-fetch": "1.3.3",
     "querystring": "0.2.0"
   }
 }

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,7 +1,0 @@
-export function requireFetch() {
-  const isClient = process.browser || false;
-
-  return isClient
-    ? window.fetch
-    : require("node-fetch");
-}

--- a/src/unsplash.js
+++ b/src/unsplash.js
@@ -1,10 +1,9 @@
 /* @flow */
 
+declare var fetch: any;
+
 import { API_URL, API_VERSION } from "./constants";
 import { buildFetchOptions } from "./utils";
-import { requireFetch } from "./services";
-
-const fetch = requireFetch();
 
 import auth from "./methods/auth";
 import currentUser from "./methods/currentUser";

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,1 @@
+global.fetch = require('node-fetch');

--- a/test/unsplash-test.js
+++ b/test/unsplash-test.js
@@ -1,6 +1,5 @@
 import Unsplash, { toJson } from "../src/unsplash.js";
 import { formUrlEncode, buildFetchOptions } from "../src/utils";
-import { requireFetch } from "../src/services";
 
 import expect, { spyOn, restoreSpies } from "expect";
 
@@ -809,16 +808,6 @@ describe("Unsplash", () => {
         let body = buildFetchOptions.bind(classFixture)(options).options.body;
 
         expect(body).toBe("foo=bar");
-      });
-    });
-  });
-
-  describe("services", () => {
-    describe("requireFetch", () => {
-      it("should require fetch client polyfill when required on the client", () => {
-        process.env.browser = true;
-
-        requireFetch();
       });
     });
   });

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -13,7 +13,6 @@ module.exports = {
     ]
   },
   plugins: [
-    new webpack.IgnorePlugin(/node-fetch/),
     new webpack.DefinePlugin({
       "process.browser": true
     })

--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -9,9 +9,7 @@ config.plugins = [
   new webpack.DefinePlugin({
     'process.env.NODE_ENV': JSON.stringify('development'),
     'process.browser': true
-  }),
-  new webpack.IgnorePlugin(/^form-data/),
-  new webpack.IgnorePlugin(/^node-fetch/)
+  })
 ];
 
 module.exports = config;

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -15,9 +15,7 @@ config.plugins = [
   new webpack.DefinePlugin({
     'process.env.NODE_ENV': JSON.stringify('production'),
     'process.browser': true
-  }),
-  new webpack.IgnorePlugin(/^form-data/),
-  new webpack.IgnorePlugin(/^node-fetch/)
+  })
 ];
 
 module.exports = config;


### PR DESCRIPTION
## Overview
- Adds React Native support
- Updates README
- Adds `.babelrc` to `.npmignore`
- Removes the node-fetch dependency
- Replaces `naoufal` with `unsplash` in docs and badge links.
