### PR TITLE
Add universal search endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,6 +794,90 @@ unsplash.collections.removePhotoFromCollection(88, 'abc1234')
 ```
 ---
 
+<div id="search" />
+
+### search.all(keyword, page)
+Get a list of photos, collections, and users matching the keyword.
+
+__Arguments__
+
+| Argument | Type | Opt/Required | Notes |
+|---|---|---|---|
+|__`keyword`__|_number_|Required||
+|__`page`__|_number_|Optional|
+
+
+__Example__
+```js
+unsplash.search.all("dogs", 2)
+  .then(toJson)
+  .then(json => {
+    // Your code
+  });
+```
+
+### search.users(keyword, page)
+Get a list of users matching the keyword.
+
+__Arguments__
+
+| Argument | Type | Opt/Required | Notes |
+|---|---|---|---|
+|__`keyword`__|_number_|Required||
+|__`page`__|_number_|Optional|
+
+
+__Example__
+```js
+unsplash.search.users("steve", 1)
+  .then(toJson)
+  .then(json => {
+    // Your code
+  });
+```
+
+### search.photos(keyword, page)
+Get a list of photos matching the keyword.
+
+__Arguments__
+
+| Argument | Type | Opt/Required | Notes |
+|---|---|---|---|
+|__`keyword`__|_number_|Required||
+|__`page`__|_number_|Optional|
+
+
+__Example__
+```js
+unsplash.search.photos("dogs", 1)
+  .then(toJson)
+  .then(json => {
+    // Your code
+  });
+```
+
+### search.collections(keyword, page)
+Get a list of collections matching the keyword.
+
+__Arguments__
+
+| Argument | Type | Opt/Required | Notes |
+|---|---|---|---|
+|__`keyword`__|_number_|Required||
+|__`page`__|_number_|Optional|
+
+
+__Example__
+```js
+unsplash.search.collections("dogs", 1)
+  .then(toJson)
+  .then(json => {
+    // Your code
+  });
+```
+
+---
+
 <div id="stats" />
 
 ### stats.total()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unsplash-js",
-  "version": "4.0.0",
+  "version": "4.2.0",
   "description": "A Universal JavaScript wrapper for the Unsplash API",
   "main": "lib/unsplash.js",
   "scripts": {

--- a/src/methods/search.js
+++ b/src/methods/search.js
@@ -1,0 +1,61 @@
+/* @flow */
+
+export default function search(): Object {
+  return {
+    all: (keyword, page = 1)  => {
+      const url = "/search";
+      const query = {
+        query: keyword,
+        page
+      };
+
+      return this.request({
+        url,
+        method: "GET",
+        query
+      });
+    },
+
+    photos: (keyword, page = 1)  => {
+      const url = "/search/photos";
+      const query = {
+        query: keyword,
+        page
+      };
+
+      return this.request({
+        url,
+        method: "GET",
+        query
+      });
+    },
+
+    users: (keyword, page = 1)  => {
+      const url = "/search/users";
+      const query = {
+        query: keyword,
+        page
+      };
+
+      return this.request({
+        url,
+        method: "GET",
+        query
+      });
+    },
+
+    collections: (keyword, page = 1)  => {
+      const url = "/search/collections";
+      const query = {
+        query: keyword,
+        page
+      };
+
+      return this.request({
+        url,
+        method: "GET",
+        query
+      });
+    }
+  };
+}

--- a/src/methods/search.js
+++ b/src/methods/search.js
@@ -2,7 +2,7 @@
 
 export default function search(): Object {
   return {
-    all: (keyword, page = 1)  => {
+    all: (keyword = "", page = 1)  => {
       const url = "/search";
       const query = {
         query: keyword,
@@ -16,7 +16,7 @@ export default function search(): Object {
       });
     },
 
-    photos: (keyword, page = 1)  => {
+    photos: (keyword = "", page = 1)  => {
       const url = "/search/photos";
       const query = {
         query: keyword,
@@ -30,7 +30,7 @@ export default function search(): Object {
       });
     },
 
-    users: (keyword, page = 1)  => {
+    users: (keyword = "", page = 1)  => {
       const url = "/search/users";
       const query = {
         query: keyword,
@@ -44,7 +44,7 @@ export default function search(): Object {
       });
     },
 
-    collections: (keyword, page = 1)  => {
+    collections: (keyword = "", page = 1)  => {
       const url = "/search/collections";
       const query = {
         query: keyword,

--- a/src/methods/search.js
+++ b/src/methods/search.js
@@ -2,60 +2,25 @@
 
 export default function search(): Object {
   return {
-    all: (keyword = "", page = 1)  => {
-      const url = "/search";
-      const query = {
-        query: keyword,
-        page
-      };
+    all: searcher.bind(this, "/search"),
 
-      return this.request({
-        url,
-        method: "GET",
-        query
-      });
-    },
+    photos: searcher.bind(this, "/search/photos"),
 
-    photos: (keyword = "", page = 1)  => {
-      const url = "/search/photos";
-      const query = {
-        query: keyword,
-        page
-      };
+    users: searcher.bind(this, "/search/users"),
 
-      return this.request({
-        url,
-        method: "GET",
-        query
-      });
-    },
-
-    users: (keyword = "", page = 1)  => {
-      const url = "/search/users";
-      const query = {
-        query: keyword,
-        page
-      };
-
-      return this.request({
-        url,
-        method: "GET",
-        query
-      });
-    },
-
-    collections: (keyword = "", page = 1)  => {
-      const url = "/search/collections";
-      const query = {
-        query: keyword,
-        page
-      };
-
-      return this.request({
-        url,
-        method: "GET",
-        query
-      });
-    }
+    collections: searcher.bind(this, "/search/collections")
   };
+}
+
+function searcher(url, keyword = "", page = 1) {
+  const query = {
+    query: keyword,
+    page
+  };
+
+  return this.request({
+    url,
+    method: "GET",
+    query
+  });
 }

--- a/src/unsplash.js
+++ b/src/unsplash.js
@@ -11,6 +11,7 @@ import users from "./methods/users";
 import photos from "./methods/photos";
 import categories from "./methods/categories";
 import collections from "./methods/collections";
+import search from "./methods/search";
 import stats from "./methods/stats";
 
 export default class Unsplash {
@@ -27,6 +28,7 @@ export default class Unsplash {
   photos: Object;
   categories: Object;
   collections: Object;
+  search: Object;
   stats: Object;
   toJson: Function;
 
@@ -53,6 +55,7 @@ export default class Unsplash {
     this.photos = photos.bind(this)();
     this.categories = categories.bind(this)();
     this.collections = collections.bind(this)();
+    this.search = search.bind(this)();
     this.stats = stats.bind(this)();
   }
 

--- a/test/unsplash-test.js
+++ b/test/unsplash-test.js
@@ -790,6 +790,21 @@ describe("Unsplash", () => {
           }
         }]);
       });
+
+      it("should submit an empty query if the keyword is an empty string", () => {
+        let spy = spyOn(unsplash, "request");
+        unsplash.search.all();
+
+        expect(spy.calls.length).toEqual(1);
+        expect(spy.calls[0].arguments).toEqual([{
+          method: "GET",
+          url: "/search",
+          query: {
+            query: "",
+            page: 1
+          }
+        }]);
+      });
     });
 
     describe("photos", () => {
@@ -803,6 +818,21 @@ describe("Unsplash", () => {
           url: "/search/photos",
           query: {
             query: "nature",
+            page: 1
+          }
+        }]);
+      });
+
+      it("should submit an empty query if the keyword is an empty string", () => {
+        let spy = spyOn(unsplash, "request");
+        unsplash.search.photos();
+
+        expect(spy.calls.length).toEqual(1);
+        expect(spy.calls[0].arguments).toEqual([{
+          method: "GET",
+          url: "/search/photos",
+          query: {
+            query: "",
             page: 1
           }
         }]);
@@ -824,6 +854,21 @@ describe("Unsplash", () => {
           }
         }]);
       });
+
+      it("should submit an empty query if the keyword is an empty string", () => {
+        let spy = spyOn(unsplash, "request");
+        unsplash.search.users();
+
+        expect(spy.calls.length).toEqual(1);
+        expect(spy.calls[0].arguments).toEqual([{
+          method: "GET",
+          url: "/search/users",
+          query: {
+            query: "",
+            page: 1
+          }
+        }]);
+      });
     });
 
     describe("collections", () => {
@@ -837,6 +882,21 @@ describe("Unsplash", () => {
           url: "/search/collections",
           query: {
             query: "water",
+            page: 1
+          }
+        }]);
+      });
+
+      it("should submit an empty query if the keyword is an empty string", () => {
+        let spy = spyOn(unsplash, "request");
+        unsplash.search.collections();
+
+        expect(spy.calls.length).toEqual(1);
+        expect(spy.calls[0].arguments).toEqual([{
+          method: "GET",
+          url: "/search/collections",
+          query: {
+            query: "",
             page: 1
           }
         }]);

--- a/test/unsplash-test.js
+++ b/test/unsplash-test.js
@@ -764,6 +764,86 @@ describe("Unsplash", () => {
     });
   });
 
+  describe("search", () => {
+    afterEach(function () {
+      restoreSpies();
+    });
+
+    let unsplash = new Unsplash({
+      applicationId,
+      secret,
+      callbackUrl
+    });
+
+    describe("all", () => {
+      it("should make a GET request to /search", () => {
+        let spy = spyOn(unsplash, "request");
+        unsplash.search.all("dog");
+
+        expect(spy.calls.length).toEqual(1);
+        expect(spy.calls[0].arguments).toEqual([{
+          method: "GET",
+          url: "/search",
+          query: {
+            query: "dog",
+            page: 1
+          }
+        }]);
+      });
+    });
+
+    describe("photos", () => {
+      it("should make a GET request to /search/photos", () => {
+        let spy = spyOn(unsplash, "request");
+        unsplash.search.photos("nature");
+
+        expect(spy.calls.length).toEqual(1);
+        expect(spy.calls[0].arguments).toEqual([{
+          method: "GET",
+          url: "/search/photos",
+          query: {
+            query: "nature",
+            page: 1
+          }
+        }]);
+      });
+    });
+
+    describe("users", () => {
+      it("should make a GET request to /search/users", () => {
+        let spy = spyOn(unsplash, "request");
+        unsplash.search.users("steve");
+
+        expect(spy.calls.length).toEqual(1);
+        expect(spy.calls[0].arguments).toEqual([{
+          method: "GET",
+          url: "/search/users",
+          query: {
+            query: "steve",
+            page: 1
+          }
+        }]);
+      });
+    });
+
+    describe("collections", () => {
+      it("should make a GET request to /search/collections", () => {
+        let spy = spyOn(unsplash, "request");
+        unsplash.search.collections("water");
+
+        expect(spy.calls.length).toEqual(1);
+        expect(spy.calls[0].arguments).toEqual([{
+          method: "GET",
+          url: "/search/collections",
+          query: {
+            query: "water",
+            page: 1
+          }
+        }]);
+      });
+    });
+  });
+
   describe("request", () => {
     // it("should call fetch", () => {
     //   let unsplash = new Unsplash({


### PR DESCRIPTION
### Overview

Adds new search endpoints for:
  - `/search`: searches collections, users & photos
  - `/search/users`: searches just users
  - `/search/photos`: searches just photos
  - `/search/collections`: searches just collections

You can then use those with:

```js
unsplash.search.all('your keyword')
unsplash.search.photos('your keyword')
unsplash.search.collections('your keyword')
unsplash.search.users('your keyword')
```