### PR TITLE
Add photo download method

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,35 @@ unsplash.photos.unlikePhoto("mtNweauBsMQ")
 ```
 ---
 
+### photos.downloadPhoto(photo)
+Trigger a download of a photo as per the [download tracking requirement of API Guidelines](https://medium.com/unsplash/unsplash-api-guidelines-triggering-a-download-c39b24e99e02).
+
+*Note*: this accepts a photo JSON object, not a URL string or photo ID. See the example below for how to pair it with other calls to trigger it.
+
+__Arguments__
+
+| Argument | Type | Opt/Required |
+|---|---|---|
+|__`photo`__|_json_|Required|
+
+__Example__
+```js
+unsplash.photos.getPhoto("mtNweauBsMQ")
+  .then(toJson)
+  .then(json => {
+    unsplash.photos.downloadPhoto(json);
+  });
+
+// or if working with an array of photos
+unsplash.search.photos("dogs", 1)
+  .then(toJson)
+  .then(json => {
+    unsplash.photos.downloadPhoto(json["results"][0]);
+  });
+```
+
+---
+
 <div id="collections" />
 
 ### collections.listCollections(page, perPage, orderBy)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ Before using the Unsplash API, you need to [register as a developer](https://uns
 --- | --- | --- | --- | --- | --- |
 Latest ✔ | Latest ✔ | Latest ✔ | Latest ✔ | Latest ✔ | 10+ ✔ |
 
+## Quick start
+
+Quick links to methods you're likely to care about:
+
+- [Get a list of new photos](#photos-all) 🎉
+- [Get a random photo](#photo-random) 🎑
+- [Trigger a photo download](#photo-download) 📡
+- [Search for a photo by keyword](#search-photos) 🕵️‍♂️
+
+**Note:** Every application must abide by the [API Guidelines](https://medium.com/unsplash/unsplash-api-guidelines-28e0216e6daa). Specifically, remember to [hotlink images](https://medium.com/unsplash/unsplash-api-guidelines-hotlinking-images-6c6b51030d2a) and [trigger a download when appropriate](https://medium.com/unsplash/unsplash-api-guidelines-triggering-a-download-c39b24e99e02).
 
 ## Documentation
 - [Installation](https://github.com/unsplash/unsplash-js#installation)
@@ -357,6 +367,8 @@ unsplash.users.collections("naoufal", 2, 15, "updated")
 
 <div id="photos" />
 
+<div id="photos-all" />
+
 ### photos.listPhotos(page, perPage, orderBy)
 Get a single page from the list of all photos.
 
@@ -440,6 +452,8 @@ unsplash.photos.getPhotoStats("mtNweauBsMQ")
 ```
 ---
 
+<div id="photo-random" />
+
 ### photos.getRandomPhoto({ width, height, query, username, featured })
 Retrieve a single random photo, given optional filters.
 
@@ -510,6 +524,8 @@ unsplash.photos.unlikePhoto("mtNweauBsMQ")
   });
 ```
 ---
+
+<div id="photo-download" />
 
 ### photos.downloadPhoto(photo)
 Trigger a download of a photo as per the [download tracking requirement of API Guidelines](https://medium.com/unsplash/unsplash-api-guidelines-triggering-a-download-c39b24e99e02).
@@ -813,6 +829,8 @@ unsplash.collections.listRelatedCollections(88)
 ---
 
 <div id="search" />
+
+<div id="search-photos" />
 
 ### search.photos(keyword, page, per_page)
 Get a list of photos matching the keyword.

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "form-urlencoded": "1.2.0",
-    "lodash": "4.17.4",
+    "lodash.get": "4.4.2",
     "querystring": "0.2.0",
     "url-parse": "1.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "dependencies": {
     "form-urlencoded": "1.2.0",
-    "querystring": "0.2.0"
+    "querystring": "0.2.0",
+    "url-parse": "1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unsplash-js",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "description": "A Universal JavaScript wrapper for the Unsplash API",
   "main": "lib/unsplash.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "dependencies": {
     "form-urlencoded": "1.2.0",
+    "lodash": "4.17.4",
     "querystring": "0.2.0",
     "url-parse": "1.2.0"
   }

--- a/src/methods/photos.js
+++ b/src/methods/photos.js
@@ -1,6 +1,6 @@
 /* @flow */
 import { getUrlComponents } from "../utils";
-import get from "lodash/get";
+import get from "lodash.get";
 
 export default function photos(): Object {
   return {

--- a/src/methods/photos.js
+++ b/src/methods/photos.js
@@ -1,4 +1,5 @@
 /* @flow */
+import { getUrlComponents } from "../utils";
 
 export default function photos(): Object {
   return {
@@ -144,6 +145,16 @@ export default function photos(): Object {
       return this.request({
         url,
         method: "DELETE"
+      });
+    },
+
+    downloadPhoto: (photo) => {
+      const urlComponents = getUrlComponents(photo["links"]["download_location"]);
+
+      return this.request({
+        url: urlComponents.pathname,
+        method: "GET",
+        query: urlComponents.query
       });
     }
   };

--- a/src/methods/photos.js
+++ b/src/methods/photos.js
@@ -1,5 +1,6 @@
 /* @flow */
 import { getUrlComponents } from "../utils";
+import get from "lodash/get";
 
 export default function photos(): Object {
   return {
@@ -149,7 +150,13 @@ export default function photos(): Object {
     },
 
     downloadPhoto: (photo) => {
-      const urlComponents = getUrlComponents(photo["links"]["download_location"]);
+      const downloadLocation = get(photo, "links.download_location", undefined);
+
+      if (downloadLocation === undefined) {
+        throw new Error(`Object received is not a photo. ${photo}`);
+      }
+
+      const urlComponents = getUrlComponents(downloadLocation);
 
       return this.request({
         url: urlComponents.pathname,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,9 +1,14 @@
 /* @flow */
 import { stringify as qsStringify } from "querystring";
 import formurlencoded from "form-urlencoded";
+import parse from "url-parse";
 
 export function formUrlEncode(body: Object): Object {
   return formurlencoded(body);
+}
+
+export function getUrlComponents(uri: String): Object {
+  return parse(uri, {}, true);
 }
 
 export function buildFetchOptions(

--- a/test/unsplash-test.js
+++ b/test/unsplash-test.js
@@ -537,6 +537,29 @@ describe("Unsplash", () => {
         }]);
       });
     });
+
+    describe("downloadPhoto", () => {
+      it("should make a GET request to the photo's download_location", () => {
+        let spy = spyOn(unsplash, "request");
+        const mockPhotoResponse = {
+          "id": "123123",
+          "links": {
+            "download_location": "https://api.unsplash.com/photos/123123/download?ixid=drake"
+          }
+        };
+
+        unsplash.photos.downloadPhoto(mockPhotoResponse);
+
+        expect(spy.calls.length).toEqual(1);
+        expect(spy.calls[0].arguments).toEqual([{
+          method: "GET",
+          url: "/photos/123123/download",
+          query: {
+            ixid: "drake"
+          }
+        }]);
+      });
+    });
   });
 
   describe("categories", () => {

--- a/test/unsplash-test.js
+++ b/test/unsplash-test.js
@@ -559,6 +559,12 @@ describe("Unsplash", () => {
           }
         }]);
       });
+
+      it("should throw an error if passed a malformed photo object", () => {
+        const mockPhotoResponse = "123123";
+
+        expect(() => unsplash.photos.downloadPhoto(mockPhotoResponse)).toThrow(/Object received is not a photo/);
+      });
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3184,6 +3184,10 @@ querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
+querystringify@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
+
 randomatic@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.6.tgz#110dcabff397e9dcff7c0789ccc0a49adf1ec5bb"
@@ -3396,7 +3400,7 @@ request@^2.65.0, request@^2.79.0:
     tunnel-agent "~0.4.1"
     uuid "^3.0.0"
 
-requires-port@1.x.x:
+requires-port@1.x.x, requires-port@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
@@ -3850,6 +3854,13 @@ unzip@~0.1.9:
     pullstream ">= 0.4.1 < 1"
     readable-stream "~1.0.31"
     setimmediate ">= 1.0.1 < 2"
+
+url-parse@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.2.0.tgz#3a19e8aaa6d023ddd27dcc44cb4fc8f7fec23986"
+  dependencies:
+    querystringify "~1.0.0"
+    requires-port "~1.0.0"
 
 url@~0.10.1:
   version "0.10.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2505,6 +2505,10 @@ lodash.clonedeep@^3.0.1:
     lodash._baseclone "^3.0.0"
     lodash._bindcallback "^3.0.0"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
@@ -2594,7 +2598,7 @@ lodash@^3.10.0, lodash@^3.2.0, lodash@^3.3.1, lodash@^3.8.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.17.4, lodash@^4.2.0:
+lodash@^4.2.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2594,7 +2594,7 @@ lodash@^3.10.0, lodash@^3.2.0, lodash@^3.3.1, lodash@^3.8.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.2.0:
+lodash@^4.17.4, lodash@^4.2.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -3855,7 +3855,7 @@ unzip@~0.1.9:
     readable-stream "~1.0.31"
     setimmediate ">= 1.0.1 < 2"
 
-url-parse@^1.2.0:
+url-parse@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.2.0.tgz#3a19e8aaa6d023ddd27dcc44cb4fc8f7fec23986"
   dependencies:


### PR DESCRIPTION
#### Overview

Adds a `photos.downloadPhoto` method to make it easier for applications to abide by the [new API Guideline](https://medium.com/unsplash/unsplash-api-guidelines-28e0216e6daa):

> When your application performs something similar to a download (like when a user chooses the image to include in a blog post, set as a wallpaper, etc.), you must send a request to the download endpoint returned under the photo.links.download_location property.

Example usage:

```js
unsplash.photos.getPhoto("mtNweauBsMQ")
  .then(toJson)
  .then(json => {
    unsplash.photos.downloadPhoto(json);
  });

// or if working with an array of photos
unsplash.search.photos("dogs", 1)
  .then(toJson)
  .then(json => {
    unsplash.photos.downloadPhoto(json["results"][0]);
  });
```