### PR TITLE
Add function to report photo views

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -2,3 +2,4 @@ export const API_URL = "https://api.unsplash.com";
 export const API_VERSION = "v1";
 export const OAUTH_AUTHORIZE_URL = "https://unsplash.com/oauth/authorize";
 export const OAUTH_TOKEN_URL = "https://unsplash.com/oauth/token";
+export const REPORTER_URL = "https://views.unsplash.com";

--- a/src/methods/auth.js
+++ b/src/methods/auth.js
@@ -7,7 +7,7 @@ export default function auth(): Object {
   return {
     getAuthenticationUrl: (scope = ["public"]) => {
       let querystrings = querystring.stringify({
-        client_id: this._applicationId,
+        client_id: this._access,
         redirect_uri: this._callbackUrl,
         response_type: "code",
         scope: scope.length > 1
@@ -25,7 +25,7 @@ export default function auth(): Object {
         url,
         method: "POST",
         body: {
-          client_id: this._applicationId,
+          client_id: this._access,
           client_secret: this._secret,
           redirect_uri: this._callbackUrl,
           grant_type: "authorization_code",

--- a/src/methods/photos.js
+++ b/src/methods/photos.js
@@ -163,6 +163,22 @@ export default function photos(): Object {
         method: "GET",
         query: urlComponents.query
       });
+    },
+
+    viewPhoto: (id) => {
+      const url = "/v";
+
+      const query = {
+        app_id: this._applicationId,
+        photo_id: Array.isArray(id) ? id.join(",") : id
+      };
+
+      return this.request({
+        url,
+        method: "GET",
+        query,
+        reporter: true
+      });
     }
   };
 }

--- a/src/methods/stats.js
+++ b/src/methods/stats.js
@@ -9,6 +9,22 @@ export default function stats(): Object {
         url,
         method: "GET"
       });
+    },
+
+    reportViews: (photoIds) => {
+      const url = "/v";
+
+      const query = {
+        app_id: this._applicationId,
+        photo_id: Array.isArray(photoIds) ? photoIds.join(",") : photoIds
+      };
+
+      return this.request({
+        url,
+        method: "GET",
+        query,
+        reporter: true
+      });
     }
   };
 }

--- a/src/methods/stats.js
+++ b/src/methods/stats.js
@@ -9,22 +9,6 @@ export default function stats(): Object {
         url,
         method: "GET"
       });
-    },
-
-    reportViews: (photoIds) => {
-      const url = "/v";
-
-      const query = {
-        app_id: this._applicationId,
-        photo_id: Array.isArray(photoIds) ? photoIds.join(",") : photoIds
-      };
-
-      return this.request({
-        url,
-        method: "GET",
-        query,
-        reporter: true
-      });
     }
   };
 }

--- a/src/unsplash.js
+++ b/src/unsplash.js
@@ -2,7 +2,7 @@
 
 declare var fetch: any;
 
-import { API_URL, API_VERSION } from "./constants";
+import { API_URL, API_VERSION, REPORTER_URL } from "./constants";
 import { buildFetchOptions } from "./utils";
 
 import auth from "./methods/auth";
@@ -17,7 +17,9 @@ import stats from "./methods/stats";
 export default class Unsplash {
   _apiUrl: string;
   _apiVersion: string;
+  _reporterUrl: string;
   _applicationId: string;
+  _access: string;
   _secret: string;
   _callbackUrl: string;
   _bearerToken: ?string;
@@ -37,7 +39,9 @@ export default class Unsplash {
     options: {
       apiUrl: string,
       apiVersion: string,
+      reporterUrl: string,
       applicationId: string,
+      access: string,
       secret: string,
       callbackUrl: string,
       bearerToken?: string,
@@ -46,7 +50,9 @@ export default class Unsplash {
   ) {
     this._apiUrl = options.apiUrl || API_URL;
     this._apiVersion = options.apiVersion || API_VERSION;
+    this._reporterUrl = options.reporterUrl || REPORTER_URL;
     this._applicationId = options.applicationId;
+    this._access = options.access;
     this._secret = options.secret;
     this._callbackUrl = options.callbackUrl;
     this._bearerToken = options.bearerToken;
@@ -69,7 +75,8 @@ export default class Unsplash {
       query: Object,
       headers: Object,
       body: Object,
-      oauth: boolean
+      oauth: boolean,
+      reporter: boolean
     }
   ):Promise<any> {
     var { url, options } = buildFetchOptions.bind(this)(requestOptions);

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -18,18 +18,21 @@ export function buildFetchOptions(
     query: Object,
     headers: Object,
     body: Object,
-    oauth: boolean
+    oauth: boolean,
+    reporter: boolean
   }
 ): Object {
-  let { method, query, oauth, body } = options;
+  let { method, query, oauth, body, reporter } = options;
+
+  let hostUrl = reporter ? this._reporterUrl : this._apiUrl;
   let url = (oauth === true)
     ? options.url
-    : `${this._apiUrl}${options.url}`;
+    : `${hostUrl}${options.url}`;
   let headers = Object.assign({}, this._headers, options.headers, {
     "Accept-Version": this._apiVersion,
     "Authorization": this._bearerToken
       ? `Bearer ${this._bearerToken}`
-      : `Client-ID ${this._applicationId}`
+      : `Client-ID ${this._access}`
   });
 
   if (body) {


### PR DESCRIPTION
#### Overview

Adds a function to report photo views for applications that wish to avoid hotlinking ([API Guidelines](https://medium.com/unsplash/unsplash-api-guidelines-28e0216e6daa)).

> All API uses must use the hotlinked image URLs returned by the API under the photo.urls properties.

When displaying a Unsplash photo that is NOT hotlinked, here's what to do:

```js
// Single photo displayed
unsplash.photos.viewPhoto("mtNweauBsMQ");

// Multiple photos displayed
unsplash.photos.viewPhoto(["mtNweauBsMQ", "htZpesuByKH"]);
```

This PR contains the minimum code to make that function a reality.

## DO NOT MERGE
It depends on https://github.com/unsplash/unsplash-js/pull/63 being merged first because the method needs the actual `Application ID` so we need to ask for both `Application ID` and `Access token` in the constructor (like it's done in the linked PR).