### PR TITLE
Update readme to reference app access key rather than ID.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ import Unsplash from 'unsplash-js';
 const Unsplash = require('unsplash-js').default;
 
 const unsplash = new Unsplash({
-  applicationId: "{APP_ID}",
+  applicationId: "{APP_ACCESS_KEY}",
   secret: "{APP_SECRET}",
   callbackUrl: "{CALLBACK_URL}"
 });
@@ -64,7 +64,7 @@ If you already have a bearer token, you can also provide it to the constructor.
 
 ```js
 const unsplash = new Unsplash({
-  applicationId: "{APP_ID}",
+  applicationId: "{APP_ACCESS_KEY}",
   secret: "{APP_SECRET}",
   callbackUrl: "{CALLBACK_URL}",
   bearerToken: "{USER_BEARER_TOKEN}"
@@ -75,7 +75,7 @@ You can also provide headers that will be set on every request by providing them
 
 ```js
 const unsplash = new Unsplash({
-  applicationId: "{APP_ID}",
+  applicationId: "{APP_ACCESS_KEY}",
   secret: "{APP_SECRET}",
   callbackUrl: "{CALLBACK_URL}",
   headers: {


### PR DESCRIPTION
#### Overview

Quick change to the readme to help clear up confusion about which value people should be configuring with.

I'll stay out of what the Right Way is to actually fix this long-term.