### PR TITLE
add collections and orientation params to unsplash.search.photos

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,7 +836,7 @@ unsplash.collections.listRelatedCollections(88)
 
 <div id="search-photos" />
 
-### search.photos(keyword, page, per_page)
+### search.photos(keyword, page, per_page,collections,orientation)
 Get a list of photos matching the keyword.
 
 __Arguments__
@@ -846,6 +846,8 @@ __Arguments__
 |__`keyword`__|_string_|Required||
 |__`page`__|_number_|Optional||
 |__`per_page`__|_number_|Optional|10|
+|__`collections`__|_Array<number>_|Optional||
+|__`orientation`__|_string_|Optional||
 
 
 __Example__

--- a/src/methods/search.js
+++ b/src/methods/search.js
@@ -2,26 +2,49 @@
 
 export default function search(): Object {
   return {
-    all: searcher.bind(this, "/search"),
+    all: universalSearcher.bind(this, "/search"),
 
-    photos: searcher.bind(this, "/search/photos"),
+    photos: photosSearcher.bind(this, "/search/photos"),
 
-    users: searcher.bind(this, "/search/users"),
+    users: universalSearcher.bind(this, "/search/users"),
 
-    collections: searcher.bind(this, "/search/collections")
+    collections: universalSearcher.bind(this, "/search/collections")
   };
 }
 
-function searcher(url, keyword = "", page = 1, per_page = 10) {
+function photosSearcher(url, keyword = "", page = 1, per_page = 10,collections = [""],orientation = undefined) {
+  const query ={
+    query: keyword,
+    page,
+    per_page,
+    collections: collections.length > 1 ? 
+      collections.join(",") : collections.toString()
+  };
+  if (orientation){
+    const defineProperty = Object.defineProperty;
+    defineProperty(query, "orientation",({
+      value:orientation,
+      configurable:true,
+      enumerable:true
+    } : Object));
+  }
+  return this.request({
+    url,
+    method: "GET",
+    query
+  }); 
+}
+
+function universalSearcher(url, keyword = "", page = 1, per_page = 10){
   const query = {
     query: keyword,
     page,
     per_page
   };
-
   return this.request({
     url,
     method: "GET",
     query
   });
 }
+

--- a/test/unsplash-test.js
+++ b/test/unsplash-test.js
@@ -909,7 +909,7 @@ describe("Unsplash", () => {
       it("should make a GET request to /search/photos", () => {
         let spy = spyOn(unsplash, "request");
         unsplash.search.photos("nature");
-
+        
         expect(spy.calls.length).toEqual(1);
         expect(spy.calls[0].arguments).toEqual([{
           method: "GET",
@@ -917,11 +917,12 @@ describe("Unsplash", () => {
           query: {
             query: "nature",
             page: 1,
-            per_page: 10
+            per_page: 10,
+            collections: ""
           }
         }]);
       });
-
+      
       it("should submit an empty query if the keyword is an empty string", () => {
         let spy = spyOn(unsplash, "request");
         unsplash.search.photos();
@@ -933,7 +934,8 @@ describe("Unsplash", () => {
           query: {
             query: "",
             page: 1,
-            per_page: 10
+            per_page: 10,
+            collections: ""
           }
         }]);
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2505,9 +2505,9 @@ lodash.clonedeep@^3.0.1:
     lodash._baseclone "^3.0.0"
     lodash._bindcallback "^3.0.0"
 
-lodash.get@^4.4.2:
+lodash.get@4.4.2:
   version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  resolved "http://registry.npm.taobao.org/lodash.get/download/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
 lodash.isarguments@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
#### Overview

add orientation and collections as a parameter to the `unsplash.search.photos` query, based on [Unsplash Developer Document](https://unsplash.com/documentation#search-photos)

Releated issue #55

