### PR TITLE
Add require syntax to 'toJson' import

### DIFF
--- a/README.md
+++ b/README.md
@@ -931,7 +931,11 @@ __Arguments__
 
 __Example__
 ```js
+// ES Modules syntax
 import Unsplash, { toJson } from "unsplash-js";
+
+// require syntax
+const toJson = require("unsplash-js").toJson;
 
 const unsplash = new Unsplash({
   applicationId: "{YOUR_ACCESS_KEY}",


### PR DESCRIPTION
Maybe a capital letter on require? But I kept it consistent with the other comment mentioning the require syntax.
