### PR TITLE
Use node 4.8.x on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "4.2"
+  - "4.8"
 script:
   - npm run test:ci
 after_success:


### PR DESCRIPTION
#### Overview

- update node since Travis dropped support for `4.2.x`