### PR TITLE
[6.0] Configure request timeouts with node-fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,14 @@ const Unsplash = require('unsplash-js').default;
 
 const unsplash = new Unsplash({ accessKey: "{APP_ACCESS_KEY}" });
 
-// Optionally you can also configure a custom header to be sent with every request
 const unsplash = new Unsplash({
   accessKey: "{APP_ACCESS_KEY}",
+  // Optionally you can also configure a custom header to be sent with every request
   headers: {
     "X-Custom-Header": "foo"
-  }
+  },
+  // Optionally if using a node-fetch polyfill or a version of fetch which supports the timeout option, you can configure the request timeout for all requests
+  timeout: 500 // values set in ms
 });
 ```
 

--- a/src/unsplash.js
+++ b/src/unsplash.js
@@ -21,6 +21,7 @@ export default class Unsplash {
   _callbackUrl: ?string;
   _bearerToken: ?string;
   _headers: ?Object;
+  _timeout: ?number;
 
   auth: Object;
   currentUser: Object;
@@ -39,7 +40,8 @@ export default class Unsplash {
       secret?: string,
       callbackUrl?: string,
       bearerToken?: string,
-      headers?: Object
+      headers?: Object,
+      timeout?: number
     }
   ) {
     this._apiUrl = options.apiUrl || API_URL;
@@ -49,6 +51,7 @@ export default class Unsplash {
     this._callbackUrl = options.callbackUrl;
     this._bearerToken = options.bearerToken;
     this._headers = options.headers || {};
+    this._timeout = options.timeout || 0; // 0 defaults to the OS timeout behaviour.
 
     this.auth = auth.bind(this)();
     this.currentUser = currentUser.bind(this)();

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -31,6 +31,7 @@ export function buildFetchOptions(
       ? `Bearer ${this._bearerToken}`
       : `Client-ID ${this._accessKey}`
   });
+  let timeout = this._timeout;
 
   if (body) {
     headers["Content-Type"] = "application/x-www-form-urlencoded";
@@ -45,6 +46,7 @@ export function buildFetchOptions(
     options: {
       method,
       headers,
+      timeout,
       body: (method !== "GET") && body
         ? formUrlEncode(body)
         : undefined

--- a/test/unsplash-test.js
+++ b/test/unsplash-test.js
@@ -7,12 +7,14 @@ const accessKey = "accessKey";
 const secret = "secret";
 const callbackUrl = "http://foo.com";
 const headers = { "X-Custom-Header": "foo" };
+const timeout = 100;
 
 describe("Unsplash", () => {
   describe("constructor", () => {
     const unsplash = new Unsplash({
       accessKey,
-      headers
+      headers,
+      timeout
     });
 
     it("should successfully construct an Unsplash instance", () => {
@@ -29,6 +31,10 @@ describe("Unsplash", () => {
 
     it("should set the headers argument on the Unsplash instance", () => {
       expect(unsplash._headers).toBe(headers);
+    });
+
+    it("should set the timeout argument on the Unsplash instance", () => {
+      expect(unsplash._timeout).toBe(timeout);
     });
 
     it("should have an auth method", () => {


### PR DESCRIPTION
#### Overview

- Add support for [node-fetch request timeout config](https://github.com/bitinn/node-fetch#options). This only works with node-fetch, as fetch doesn't seem to support a `timeout` option
- Re #105 