### PR TITLE
Rename downloadPhoto to trackDownload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6.3.0
+
+### Changes
+
+- Deprecate `photos.photoDownload` in favor of `photos.trackDownload` to better clarify method usage. `photoDownload` will continue to be supported until version 7.0.
+
 ## 6.2.0
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Quick links to methods you're likely to care about:
 
 - [Get a list of new photos](#photos-all) 🎉
 - [Get a random photo](#photo-random) 🎑
-- [Trigger a photo download](#photo-download) 📡
+- [Trigger a photo download](#track-download) 📡
 - [Search for a photo by keyword](#search-photos) 🕵️‍♂️
 
 **Note:** Every application must abide by the [API Guidelines](https://help.unsplash.com/api-guidelines/unsplash-api-guidelines). Specifically, remember to [hotlink images](https://help.unsplash.com/api-guidelines/more-on-each-guideline/guideline-hotlinking-images), [attribute photographers](https://help.unsplash.com/api-guidelines/more-on-each-guideline/guideline-attribution), and [trigger a download when appropriate](https://help.unsplash.com/api-guidelines/more-on-each-guideline/guideline-triggering-a-download).
@@ -310,9 +310,9 @@ unsplash.photos.unlikePhoto("mtNweauBsMQ")
 ```
 ---
 
-<div id="photo-download" />
+<div id="track-download" />
 
-### photos.downloadPhoto(photo)
+### photos.trackDownload(photo)
 Trigger a download of a photo as per the [download tracking requirement of API Guidelines](https://medium.com/unsplash/unsplash-api-guidelines-triggering-a-download-c39b24e99e02). [See endpoint docs 🚀](https://unsplash.com/documentation#track-a-photo-download)
 
 *Note*: this accepts a photo JSON object, not a URL string or photo ID. See the example below for how to pair it with other calls to trigger it.
@@ -328,14 +328,14 @@ __Example__
 unsplash.photos.getPhoto("mtNweauBsMQ")
   .then(toJson)
   .then(json => {
-    unsplash.photos.downloadPhoto(json);
+    unsplash.photos.trackDownload(json);
   });
 
 // or if working with an array of photos
 unsplash.search.photos("dogs", 1)
   .then(toJson)
   .then(json => {
-    unsplash.photos.downloadPhoto(json["results"][0]);
+    unsplash.photos.trackDownload(json["results"][0]);
   });
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "unsplash-js",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unsplash-js",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "A JavaScript wrapper for the Unsplash API",
   "main": "lib/unsplash.js",
   "scripts": {

--- a/src/methods/photos.js
+++ b/src/methods/photos.js
@@ -89,20 +89,25 @@ export default function photos() {
       });
     },
 
-    downloadPhoto: (photo) => {
-      const downloadLocation = get(photo, "links.download_location", undefined);
+    // Deprecated in 6.2
+    downloadPhoto: track.bind(this),
 
-      if (downloadLocation === undefined) {
-        throw new Error(`Object received is not a photo. ${photo}`);
-      }
-
-      const urlComponents = getUrlComponents(downloadLocation);
-
-      return this.request({
-        url: urlComponents.pathname,
-        method: "GET",
-        query: urlComponents.query
-      });
-    }
+    trackDownload: track.bind(this)
   };
+}
+
+function track(photo) {
+  const downloadLocation = get(photo, "links.download_location", undefined);
+
+  if (downloadLocation === undefined) {
+    throw new Error(`Object received is not a photo. ${photo}`);
+  }
+
+  const urlComponents = getUrlComponents(downloadLocation);
+
+  return this.request({
+    url: urlComponents.pathname,
+    method: "GET",
+    query: urlComponents.query
+  });
 }

--- a/test/unsplash-test.js
+++ b/test/unsplash-test.js
@@ -485,6 +485,35 @@ describe("Unsplash", () => {
         expect(() => unsplash.photos.downloadPhoto(mockPhotoResponse)).toThrow(/Object received is not a photo/);
       });
     });
+
+    describe("trackDownload", () => {
+      it("should make a GET request to the photo's download_location", () => {
+        let spy = spyOn(unsplash, "request");
+        const mockPhotoResponse = {
+          "id": "123123",
+          "links": {
+            "download_location": "https://api.unsplash.com/photos/123123/download?ixid=drake"
+          }
+        };
+
+        unsplash.photos.trackDownload(mockPhotoResponse);
+
+        expect(spy.calls.length).toEqual(1);
+        expect(spy.calls[0].arguments).toEqual([{
+          method: "GET",
+          url: "/photos/123123/download",
+          query: {
+            ixid: "drake"
+          }
+        }]);
+      });
+
+      it("should throw an error if passed a malformed photo object", () => {
+        const mockPhotoResponse = "123123";
+
+        expect(() => unsplash.photos.trackDownload(mockPhotoResponse)).toThrow(/Object received is not a photo/);
+      });
+    });
   });
 
   describe("collections", () => {


### PR DESCRIPTION
#### Overview

- continue to support `photos.downloadPhoto` but add and document `photos.trackDownload` in its favor