### PR TITLE
Fix circular type reference error for JSON

### DIFF
--- a/src/helpers/typescript.ts
+++ b/src/helpers/typescript.ts
@@ -1,7 +1,7 @@
 // Copied from https://github.com/Microsoft/TypeScript/issues/1897#issuecomment-338650717
 export type AnyJson = boolean | number | string | null | JsonArray | JsonMap;
-export type JsonMap = { [key: string]: AnyJson };
-export type JsonArray = Array<AnyJson>;
+export interface JsonMap { [key: string]: AnyJson }
+export interface JsonArray extends Array<AnyJson> {}
 
 export const checkIsString = getRefinement(
   (value: unknown): Nullable<string> => (typeof value === 'string' ? value : null),


### PR DESCRIPTION
In certain versions of Typescript, the build fails due to circular references for `AnyJson` and `JsonArray`  due to the way the typings are specified in `typescript.d.ts`.

![unsplash-js](https://user-images.githubusercontent.com/1106939/116797479-c26b5e00-ab03-11eb-93b9-bed57b1ad425.png)

The problem originates from the fact that any typings declared as `type` cannot reference itself later, whereas types declared as `interface` can.

Since this approach was inspired from [this comment](https://github.com/Microsoft/TypeScript/issues/1897#issuecomment-338650717), the fix involves going to an interface declaration as per the original source.