### PR TITLE
Adding topics to getRandom

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,8 @@ Retrieve a single random photo, given optional filters. [See endpoint docs 🚀]
 | **`query`**         | _string_        | Optional     |
 | **`username`**      | _string_        | Optional     |
 | **`featured`**      | _boolean_       | Optional     |
-| **`collectionIds`** | _Array<number>_ | Optional     |
+| **`collectionIds`** | _Array<string>_ | Optional     |
+| **`topicIds`**      | _Array<string>_ | Optional     |
 | **`count`**         | _string_        | Optional     |
 
 **Example**
@@ -399,6 +400,7 @@ unsplash.photos.getRandom({
 });
 unsplash.photos.getRandom({
   collectionIds: ['abc123'],
+  topicIds: ['def456'],
   featured: true,
   username: 'naoufal',
   query: 'dog',

--- a/src/helpers/query.ts
+++ b/src/helpers/query.ts
@@ -5,6 +5,9 @@ import { isDefined } from './typescript';
 export const getCollections = (collectionIds?: string[]) =>
   isDefined(collectionIds) ? { collections: collectionIds.join() } : {};
 
+export const getTopics = (topicIds?: string[]) =>
+  isDefined(topicIds) ? { topics: topicIds.join() } : {};
+
 export const getFeedParams = ({ page, perPage, orderBy }: PaginationParams) =>
   compactDefined({
     per_page: perPage,

--- a/src/methods/photos/index.ts
+++ b/src/methods/photos/index.ts
@@ -51,6 +51,16 @@ export const getStats = (() => {
   });
 })();
 
+export interface RandomParams {
+  collectionIds?: string[];
+  topicIds?: string[];
+  featured?: boolean;
+  username?: string;
+  query?: string;
+  contentFilter?: 'low' | 'high';
+  count?: number;
+}
+
 export const getRandom = (() => {
   const getPathname = () => `${PHOTOS_PATH_PREFIX}/random`;
   return makeEndpoint({
@@ -59,20 +69,15 @@ export const getRandom = (() => {
       ({
         collectionIds,
         contentFilter,
+        topicIds,
         ...queryParams
-      }: {
-        collectionIds?: string[];
-        featured?: boolean;
-        username?: string;
-        query?: string;
-        contentFilter?: 'low' | 'high';
-        count?: number;
-      } & OrientationParam = {}) => ({
+      }: RandomParams & OrientationParam = {}) => ({
         pathname: getPathname(),
         query: compactDefined({
           ...queryParams,
           content_filter: contentFilter,
           ...Query.getCollections(collectionIds),
+          ...Query.getTopics(topicIds),
         }),
         headers: {
           /**

--- a/src/methods/photos/index.ts
+++ b/src/methods/photos/index.ts
@@ -51,7 +51,7 @@ export const getStats = (() => {
   });
 })();
 
-export interface RandomParams {
+export type RandomParams = {
   collectionIds?: string[];
   topicIds?: string[];
   featured?: boolean;
@@ -59,19 +59,14 @@ export interface RandomParams {
   query?: string;
   contentFilter?: 'low' | 'high';
   count?: number;
-}
+} & OrientationParam;
 
 export const getRandom = (() => {
   const getPathname = () => `${PHOTOS_PATH_PREFIX}/random`;
   return makeEndpoint({
     getPathname,
     handleRequest: createRequestHandler(
-      ({
-        collectionIds,
-        contentFilter,
-        topicIds,
-        ...queryParams
-      }: RandomParams & OrientationParam = {}) => ({
+      ({ collectionIds, contentFilter, topicIds, ...queryParams }: RandomParams = {}) => ({
         pathname: getPathname(),
         query: compactDefined({
           ...queryParams,


### PR DESCRIPTION
#### Overview

Yo. I'm trying to add topicIds support to the `getRandom` endpoint. No idea if I'm going about it right. I also keep running into this error (unrelated to the code I wrote) while building:
```
/src/helpers/errors.ts(24,5): semantic error TS2322:
Type 'NonEmptyArray<AnyJson> | null' is not assignable to type 'Nullable<NonEmptyArray<string>>'.
  Type 'NonEmptyArray<AnyJson>' is not assignable to type 'Nullable<NonEmptyArray<string>>'.
   Type 'AnyJson' is not assignable to type 'string'.
      Type 'null' is not assignable to type 'string'.
```
I'm not sure what the issue is after looking at the file referenced.

#### Todo

Add docs and tests.

If someone can verify I'm doing this the right way, I can add docs and tests and finish up the PR.
