### PR TITLE
Remove content-type dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,8 +75,5 @@
     "url": "https://github.com/unsplash/unsplash-js/issues"
   },
   "homepage": "https://github.com/unsplash/unsplash-js#readme",
-  "dependencies": {
-    "@types/content-type": "^1.1.3",
-    "content-type": "^1.0.4"
-  }
+  "dependencies": {}
 }

--- a/src/helpers/fp.ts
+++ b/src/helpers/fp.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-redeclare */
+
 import { isDefined } from './typescript';
 
 /** Takes a dictionary containing nullish values and returns a dictionary of all the defined

--- a/src/helpers/json.ts
+++ b/src/helpers/json.ts
@@ -2,14 +2,12 @@ import * as ContentTypeHelpers from 'content-type';
 import { DecodingError } from './errors';
 import { AnyJson, isDefined } from './typescript';
 
-const CONTENT_TYPE_RESPONSE_HEADER = 'content-type';
-const CONTENT_TYPE_JSON = 'application/json';
 const checkIsJsonResponse = (response: Response) => {
-  const contentTypeHeader = response.headers.get(CONTENT_TYPE_RESPONSE_HEADER);
+  const contentTypeHeader = response.headers.get('content-type');
 
   return (
     isDefined(contentTypeHeader) &&
-    ContentTypeHelpers.parse(contentTypeHeader).type === CONTENT_TYPE_JSON
+    ContentTypeHelpers.parse(contentTypeHeader).type === 'application/json'
   );
 };
 

--- a/src/helpers/json.ts
+++ b/src/helpers/json.ts
@@ -1,14 +1,14 @@
-import * as ContentTypeHelpers from 'content-type';
 import { DecodingError } from './errors';
 import { AnyJson, isDefined } from './typescript';
 
-const checkIsJsonResponse = (response: Response) => {
+// Regex from: https://stackoverflow.com/a/73613161
+const isJSON = (contentType: string): boolean =>
+  /application\/[^+]*[+]?(json);?.*/.test(contentType);
+
+const checkIsJsonResponse = (response: Response): boolean => {
   const contentTypeHeader = response.headers.get('content-type');
 
-  return (
-    isDefined(contentTypeHeader) &&
-    ContentTypeHelpers.parse(contentTypeHeader).type === 'application/json'
-  );
+  return isDefined(contentTypeHeader) && isJSON(contentTypeHeader);
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1207,11 +1207,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/content-type@^1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@types/content-type/-/content-type-1.1.3.tgz#3688bd77fc12f935548eef102a4e34c512b03a07"
-  integrity sha512-pv8VcFrZ3fN93L4rTNIbbUzdkzjEyVMp5mPVjsFfOYTDOZMZiZ8P1dhu+kEv3faYyKzZgLlSvnyQNFg+p/v5ug==
-
 "@types/estree@*":
   version "0.0.45"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.45.tgz#e9387572998e5ecdac221950dab3e8c3b16af884"
@@ -2623,7 +2618,7 @@ content-disposition@0.5.3:
   dependencies:
     safe-buffer "5.1.2"
 
-content-type@^1.0.4, content-type@~1.0.4:
+content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==


### PR DESCRIPTION
Our size-limit action is broken, but I see this locally:

```console
$ git switch master
$ yarn install
$ yarn run build
$ yarn run size
 dist/unsplash-js.cjs.production.min.js
  Size limit: 5 KB
  Size:       4.21 KB with all dependencies, minified and gzipped

 dist/unsplash-js.esm.js
  Size limit: 5 KB
  Size:       4.22 KB with all dependencies, minified and gzipped

$ git switch content-type
$ yarn install
$ yarn run build
$ yarn run size
 dist/unsplash-js.cjs.production.min.js
  Size limit: 5 KB
  Size:       3.51 KB with all dependencies, minified and gzipped

 dist/unsplash-js.esm.js
  Size limit: 5 KB
  Size:       3.54 KB with all dependencies, minified and gzipped
```