### PR TITLE
Changed type of Errors object in errors.ts so that project can build …

### DIFF
--- a/src/helpers/errors.ts
+++ b/src/helpers/errors.ts
@@ -9,7 +9,7 @@ import {
   Nullable,
 } from './typescript';
 
-export type Errors = NonEmptyArray<string>;
+export type Errors = NonEmptyArray<AnyJson>;
 export type ErrorSource = 'api' | 'decoding';
 
 const checkIsObject = getRefinement(


### PR DESCRIPTION
Compiles and all tests succeed on command 'npm test'

#### Overview

- Changes type from NonEmptyArray\<string\> to NonEmptyArray\<AnyJson\> so that fresh installs can compile/build
- May require further testing but the tests that run with 'npm test' all succeed 
- Closes # 213
